### PR TITLE
Adjusting weights on cocaine.

### DIFF
--- a/resources/usa_cocaine/sv_coke.lua
+++ b/resources/usa_cocaine/sv_coke.lua
@@ -3,7 +3,7 @@ local uncutCocaine = {
     legality = "illegal",
     quantity = 1,
     type = "chemical",
-    weight = 10
+    weight = 4
 }
 
 local cocaineProduced = {
@@ -11,7 +11,7 @@ local cocaineProduced = {
 	type = "drug",
 	legality = "illegal",
 	quantity = 1,
-	weight = 6
+	weight = 8
 }
 
 RegisterServerEvent("cocaineJob:givePackaged")


### PR DESCRIPTION
I believe the weights on the unprocessed cocaine should be lower than a packaged bag. Since you add multiple ingredients to your raw cut cocaine to produce a packaged bag.