### PR TITLE
fix(AdminMenu): Unban Perms Fix

### DIFF
--- a/resources/erp_adminmenu/server/server.lua
+++ b/resources/erp_adminmenu/server/server.lua
@@ -321,7 +321,7 @@ AddEventHandler('erp_adminmenu:unbanPlayer', function(banid)
     local banid = banid
 	local group = exports["essentialmode"]:getPlayerFromId(source).getGroup()
 
-	if group == "owner" or group == "superadmin" or group == "admin" and banid then
+	if group == "owner" or group == "superadmin" and banid then
 		if GetResourceState("oxmysql") == "started" then
 			exports.oxmysql:execute("DELETE FROM bannedplayers WHERE id=:id", { id = tonumber(banid)}, function(result)
 				if result > 0 then

--- a/resources/erp_adminmenu/server/server.lua
+++ b/resources/erp_adminmenu/server/server.lua
@@ -321,7 +321,7 @@ AddEventHandler('erp_adminmenu:unbanPlayer', function(banid)
     local banid = banid
 	local group = exports["essentialmode"]:getPlayerFromId(source).getGroup()
 
-	if userGroup == "owner" or userGroup == "superadmin" or userGroup == "admin" and banid then
+	if group == "owner" or group == "superadmin" or group == "admin" and banid then
 		if GetResourceState("oxmysql") == "started" then
 			exports.oxmysql:execute("DELETE FROM bannedplayers WHERE id=:id", { id = tonumber(banid)}, function(result)
 				if result > 0 then


### PR DESCRIPTION
It worked for me and @Crownapple because when I first tested it I did

local userGroup = exports["essentialmode"]:getPlayerFromId(source).getGroup()
if userGroup == "owner" or userGroup == "superadmin" or userGroup == "admin" and banid then

But I changed it after we tested to

local group = exports["essentialmode"]:getPlayerFromId(source).getGroup()

I just forgot to change

if userGroup == "owner" or userGroup == "superadmin" or userGroup == "admin" and banid then

to

if group == "owner" or group == "superadmin" or group == "admin" and banid then

so the perms weren't registering for unban

Issue #1177 can now be closed