### PR TITLE
update(Impound): Impound CMD Updates

### DIFF
--- a/resources/usa_rp2/server.lua
+++ b/resources/usa_rp2/server.lua
@@ -237,7 +237,11 @@ AddEventHandler("usa:loadPlayerComponents", function(id)
 end)
 
 TriggerEvent('es:addJobCommand', 'impound', { "sheriff", "ems", "corrections" }, function(source, args, char)
-	TriggerClientEvent('impoundVehicle', source)
+	if exports["usa-characters"]:GetNumCharactersWithJob("mechanic") < 3 then
+		TriggerClientEvent('impoundVehicle', source)
+	else
+		TriggerClientEvent("usa:notify", source, "Must call a mechanic!")
+	end
 end, { help = "Impound a vehicle." })
 
 TriggerEvent('es:addCommand', 'dv', function(source, args, char)


### PR DESCRIPTION
The /impound command will no longer work if 3 or more mechanics are on duty. If there are not 3 or more mechanics on duty then the command will function as it used to.