### PR TITLE
update(ObjectMenu): Event Planners Now Have Access

### DIFF
--- a/resources/scenemenu/server.lua
+++ b/resources/scenemenu/server.lua
@@ -1,7 +1,8 @@
 local ALLOWED_JOBS = {
     sheriff = true,
     corrections = true,
-    ems = true
+    ems = true,
+    eventPlanner = true
 }
 
 RegisterServerEvent('ZoneActivated')


### PR DESCRIPTION
Event planners now have access to the object menu when clocked on.
F6 to open the menu

Issue: #1036 Completed