### PR TITLE
Fixes Player Owned Business Robbery Bonus When Cops Online  | (helps with #2323)

### DIFF
--- a/resources/storeRobberies/configs/config.lua
+++ b/resources/storeRobberies/configs/config.lua
@@ -11,7 +11,7 @@ Config.CopJobs = { --Set your police job names here. IF YOU ARE USING VRP SET YO
     "corrections"
 }
 
-Config.NoRobPolice = false --If set to true, policemen cannot start the robbery by aiming.
+Config.NoRobPolice = true --If set to true, policemen cannot start the robbery by aiming.
 
 Config.vRP_Permissions = { --IF YOU ARE USING VRP SET THE PERMISSIONS HERE FOR COPS.
     "police.service",

--- a/resources/usa-businesses/cl_config.lua
+++ b/resources/usa-businesses/cl_config.lua
@@ -1,5 +1,5 @@
-POLICE_NEEDED = 2
-policeNeededForBonus = 3
+POLICE_NEEDED = 0
+policeNeededForBonus = 0
 robberyCooldown = 2100
 
 LEASE_PERIOD_DAYS = 14

--- a/resources/usa-businesses/robberies/sv_robbery.lua
+++ b/resources/usa-businesses/robberies/sv_robbery.lua
@@ -52,7 +52,7 @@ AddEventHandler('business:finishRobbery', function(storeName)
 				local policeOnline = exports["usa-characters"]:GetNumCharactersWithJob("sheriff")
 				local bonus = 0
 				if policeOnline >= policeNeededForBonus then
-					bonus = math.floor(reward * 0.40)
+					bonus = math.floor(reward * 0.50)
 				end
 				char.giveMoney(reward + bonus)
 				print("ROBBERY: "..GetPlayerName(usource)..'['..GetPlayerIdentifier(usource).."] has been rewarded reward: "..(reward + bonus))

--- a/resources/usa-businesses/sv_config.lua
+++ b/resources/usa-businesses/sv_config.lua
@@ -1,5 +1,5 @@
 POLICE_NEEDED = 0
-policeNeededForBonus = 3
+policeNeededForBonus = 0
 robberyCooldown = 2100
 
 LEASE_PERIOD_DAYS = 14


### PR DESCRIPTION
usa-businesses | changed:

policeNeededforBonus = 0
POLICE_NEEDED = 0

(CL and SV config)

usa-businesses/robberies | changed:

bonus = math.floor(reward * 0.50)

**in theory now when there are more than 0 cops online, there should be a bonus applied to robberies**

**also cops can no longer start a store robbery by aiming their gun when breaching a store**
